### PR TITLE
Use market.endTime price not resolveMarket time price

### DIFF
--- a/contracts/src/BetRegistry.sol
+++ b/contracts/src/BetRegistry.sol
@@ -140,7 +140,7 @@ contract BetRegistry is IBetRegistry, Ownable {
         Market storage market = markets[marketId_];
         require(block.timestamp >= market.endTime, "BetRegistry::resolveMarket: market has not ended.");
         require(block.timestamp >= market.endTime + gracePeriod, "BetRegistry::resolveMarket: grace period not over.");
-        uint256 price = priceFeed.getPrice();
+        uint256 price = priceFeed.getPrice(block.timestamp - market.endTime);
         require(price != market.targetPrice, "BetRegistry::resolveMarket: endPrice and targetPrice must differ.");
         market.endPrice = price;
 

--- a/contracts/src/BetRegistry.sol
+++ b/contracts/src/BetRegistry.sol
@@ -140,7 +140,8 @@ contract BetRegistry is IBetRegistry, Ownable {
         Market storage market = markets[marketId_];
         require(block.timestamp >= market.endTime, "BetRegistry::resolveMarket: market has not ended.");
         require(block.timestamp >= market.endTime + gracePeriod, "BetRegistry::resolveMarket: grace period not over.");
-        uint256 price = priceFeed.getPrice(block.timestamp - market.endTime);
+        uint32 secondsAgo = uint32(block.timestamp - market.endTime);
+        uint256 price = priceFeed.getPrice(secondsAgo);
         require(price != market.targetPrice, "BetRegistry::resolveMarket: endPrice and targetPrice must differ.");
         market.endPrice = price;
 

--- a/contracts/src/PriceFeed.sol
+++ b/contracts/src/PriceFeed.sol
@@ -20,17 +20,17 @@ contract PriceFeed is IPriceFeed {
     }
 
     /// @dev returns the usdc value of 1 mio DEGEN
-    function getPrice(uint128 secondsAgo_) external view returns (uint256) {
+    function getPrice(uint32 secondsAgo_) external view returns (uint256) {
         return degenToUsdc(1e6 * 1e18, secondsAgo_);
     }
 
-    function degenToUsdc(uint128 degenAmount_, uint128 secondsAgo_) public view returns (uint256) {
+    function degenToUsdc(uint128 degenAmount_, uint32 secondsAgo_) public view returns (uint256) {
         uint256 quoteEth = degenToEth(degenAmount_, secondsAgo_);
         uint256 quoteUsdc = ethToUsdc(uint128(quoteEth), secondsAgo_);
         return quoteUsdc;
     }
 
-    function degenToEth(uint128 degenAmount_, uint128 secondsAgo_) public view returns (uint256) {
+    function degenToEth(uint128 degenAmount_, uint32 secondsAgo_) public view returns (uint256) {
         uint32[] memory secondsAgos = new uint32[](2);
         secondsAgos[0] = secondsAgo_ + 60;
         secondsAgos[1] = secondsAgo_;
@@ -41,7 +41,7 @@ contract PriceFeed is IPriceFeed {
         return quote;
     }
 
-    function ethToUsdc(uint128 ethAmount_, uint128 secondsAgo_) public view returns (uint256) {
+    function ethToUsdc(uint128 ethAmount_, uint32 secondsAgo_) public view returns (uint256) {
         uint32[] memory secondsAgos = new uint32[](2);
         secondsAgos[0] = secondsAgo_ + 60;
         secondsAgos[1] = secondsAgo_;

--- a/contracts/src/PriceFeed.sol
+++ b/contracts/src/PriceFeed.sol
@@ -20,20 +20,20 @@ contract PriceFeed is IPriceFeed {
     }
 
     /// @dev returns the usdc value of 1 mio DEGEN
-    function getPrice() external view returns (uint256) {
-        return degenToUsdc(1e6 * 1e18);
+    function getPrice(uint128 secondsAgo_) external view returns (uint256) {
+        return degenToUsdc(1e6 * 1e18, secondsAgo_);
     }
 
-    function degenToUsdc(uint128 degenAmount_) public view returns (uint256) {
-        uint256 quoteEth = degenToEth(degenAmount_);
-        uint256 quoteUsdc = ethToUsdc(uint128(quoteEth));
+    function degenToUsdc(uint128 degenAmount_, uint128 secondsAgo_) public view returns (uint256) {
+        uint256 quoteEth = degenToEth(degenAmount_, secondsAgo_);
+        uint256 quoteUsdc = ethToUsdc(uint128(quoteEth), secondsAgo_);
         return quoteUsdc;
     }
 
-    function degenToEth(uint128 degenAmount_) public view returns (uint256) {
+    function degenToEth(uint128 degenAmount_, uint128 secondsAgo_) public view returns (uint256) {
         uint32[] memory secondsAgos = new uint32[](2);
-        secondsAgos[0] = 0;
-        secondsAgos[1] = 60;
+        secondsAgos[0] = secondsAgo_;
+        secondsAgos[1] = secondsAgo_ + 60;
         (int56[] memory tickCumulatives,) = ethDegenPool.observe(secondsAgos);
         int56 tickCumulative = tickCumulatives[1] - tickCumulatives[0];
         int56 avgTickCumulative = tickCumulative / 60; // 0, 60 seconds
@@ -41,10 +41,10 @@ contract PriceFeed is IPriceFeed {
         return quote;
     }
 
-    function ethToUsdc(uint128 ethAmount_) public view returns (uint256) {
+    function ethToUsdc(uint128 ethAmount_, uint128 secondsAgo_) public view returns (uint256) {
         uint32[] memory secondsAgos = new uint32[](2);
-        secondsAgos[0] = 0;
-        secondsAgos[1] = 60;
+        secondsAgos[0] = secondsAgo_;
+        secondsAgos[1] = secondsAgo_ + 60;
         (int56[] memory tickCumulatives,) = ethUsdcPool.observe(secondsAgos);
         int56 tickCumulative = tickCumulatives[1] - tickCumulatives[0];
         int56 avgTickCumulative = tickCumulative / 60; // 0, 60 seconds

--- a/contracts/src/PriceFeed.sol
+++ b/contracts/src/PriceFeed.sol
@@ -32,23 +32,23 @@ contract PriceFeed is IPriceFeed {
 
     function degenToEth(uint128 degenAmount_, uint128 secondsAgo_) public view returns (uint256) {
         uint32[] memory secondsAgos = new uint32[](2);
-        secondsAgos[0] = secondsAgo_;
-        secondsAgos[1] = secondsAgo_ + 60;
+        secondsAgos[0] = secondsAgo_ + 60;
+        secondsAgos[1] = secondsAgo_;
         (int56[] memory tickCumulatives,) = ethDegenPool.observe(secondsAgos);
-        int56 tickCumulative = tickCumulatives[1] - tickCumulatives[0];
-        int56 avgTickCumulative = tickCumulative / 60; // 0, 60 seconds
-        uint256 quote = OracleLibrary.getQuoteAtTick(int24(avgTickCumulative), degenAmount_, WETH_BASE, DEGEN_BASE);
+        int56 tickCumulativeDelta = tickCumulatives[1] - tickCumulatives[0];
+        int56 avgTick = tickCumulativeDelta / 60; // 0, 60 seconds
+        uint256 quote = OracleLibrary.getQuoteAtTick(int24(avgTick), degenAmount_, WETH_BASE, DEGEN_BASE);
         return quote;
     }
 
     function ethToUsdc(uint128 ethAmount_, uint128 secondsAgo_) public view returns (uint256) {
         uint32[] memory secondsAgos = new uint32[](2);
-        secondsAgos[0] = secondsAgo_;
-        secondsAgos[1] = secondsAgo_ + 60;
+        secondsAgos[0] = secondsAgo_ + 60;
+        secondsAgos[1] = secondsAgo_;
         (int56[] memory tickCumulatives,) = ethUsdcPool.observe(secondsAgos);
-        int56 tickCumulative = tickCumulatives[1] - tickCumulatives[0];
-        int56 avgTickCumulative = tickCumulative / 60; // 0, 60 seconds
-        uint256 quote = OracleLibrary.getQuoteAtTick(int24(avgTickCumulative), ethAmount_, USDC_BASE, WETH_BASE);
+        int56 tickCumulativeDelta = tickCumulatives[1] - tickCumulatives[0];
+        int56 avgTick = tickCumulativeDelta / 60; // 0, 60 seconds
+        uint256 quote = OracleLibrary.getQuoteAtTick(int24(avgTick), ethAmount_, USDC_BASE, WETH_BASE);
         return quote;
     }
 }

--- a/contracts/src/auxiliary/MockPriceFeed.sol
+++ b/contracts/src/auxiliary/MockPriceFeed.sol
@@ -8,7 +8,7 @@ contract MockPriceFeed {
     uint256 price;
 
     /// @dev returns the usdc value of 1 mio DEGEN
-    function getPrice() external view returns (uint256) {
+    function getPrice(uint128 secondsAgo_) external view returns (uint256) {
         return price;
     }
 

--- a/contracts/src/interfaces/IPriceFeed.sol
+++ b/contracts/src/interfaces/IPriceFeed.sol
@@ -2,11 +2,11 @@
 pragma solidity ^0.8.18;
 
 interface IPriceFeed {
-    function getPrice() external view returns (uint256);
+    function getPrice(uint128 secondsAgo) external view returns (uint256);
 
-    function degenToUsdc(uint128 degenAmountk) external view returns (uint256);
+    function degenToUsdc(uint128 degenAmount, uint128 secondsAgo) external view returns (uint256);
 
-    function degenToEth(uint128 degenAmount) external view returns (uint256);
+    function degenToEth(uint128 degenAmount, uint128 secondsAgo) external view returns (uint256);
 
-    function ethToUsdc(uint128 ethAmount) external view returns (uint256);
+    function ethToUsdc(uint128 ethAmount, uint128 secondsAgo) external view returns (uint256);
 }

--- a/contracts/src/interfaces/IPriceFeed.sol
+++ b/contracts/src/interfaces/IPriceFeed.sol
@@ -2,11 +2,11 @@
 pragma solidity ^0.8.18;
 
 interface IPriceFeed {
-    function getPrice(uint128 secondsAgo) external view returns (uint256);
+    function getPrice(uint32 secondsAgo) external view returns (uint256);
 
-    function degenToUsdc(uint128 degenAmount, uint128 secondsAgo) external view returns (uint256);
+    function degenToUsdc(uint128 degenAmount, uint32 secondsAgo) external view returns (uint256);
 
-    function degenToEth(uint128 degenAmount, uint128 secondsAgo) external view returns (uint256);
+    function degenToEth(uint128 degenAmount, uint32 secondsAgo) external view returns (uint256);
 
-    function ethToUsdc(uint128 ethAmount, uint128 secondsAgo) external view returns (uint256);
+    function ethToUsdc(uint128 ethAmount, uint32 secondsAgo) external view returns (uint256);
 }

--- a/contracts/test/PriceFeed_Basic.t.sol
+++ b/contracts/test/PriceFeed_Basic.t.sol
@@ -13,24 +13,24 @@ contract PriceFeed_Basic_Test is Test, WithTestHelpers {
     }
 
     function test_getPrice() public {
-        assertEq(priceFeed.degenToEth(1e6 * 1e18), 273_450_722_395_988_893, "1mio degenToEth should be ~0.273");
-        assertEq(priceFeed.ethToUsdc(1 * 1e18), 2940_995_255, "ethToUsdc");
-        assertEq(priceFeed.degenToUsdc(1e6 * 1e18), 804_217_277, "1mio degenToUsdc should be ~$804");
-        assertEq(priceFeed.getPrice(), DEGEN_PRICE_1, "getPrice should be 804_217_277");
+        assertEq(priceFeed.degenToEth(1e6 * 1e18, 0), 273_450_722_395_988_893, "1mio degenToEth should be ~0.273");
+        assertEq(priceFeed.ethToUsdc(1 * 1e18, 0), 2940_995_255, "ethToUsdc");
+        assertEq(priceFeed.degenToUsdc(1e6 * 1e18, 0), 804_217_277, "1mio degenToUsdc should be ~$804");
+        assertEq(priceFeed.getPrice(0), DEGEN_PRICE_1, "getPrice should be 804_217_277");
     }
 
     function test_togglePrice() public {
-        assertEq(priceFeed.getPrice(), DEGEN_PRICE_1, "getPrice should be 804_217_277");
+        assertEq(priceFeed.getPrice(0), DEGEN_PRICE_1, "getPrice should be 804_217_277");
         ethDegenPool.togglePrice();
         ethUsdcPool.togglePrice();
-        assertEq(priceFeed.getPrice(), DEGEN_PRICE_2, "getPrice should be 1_000_000_000");
+        assertEq(priceFeed.getPrice(0), DEGEN_PRICE_2, "getPrice should be 1_000_000_000");
     }
 
     function test_mockPriceFeed() public {
         MockPriceFeed mockPriceFeed = new MockPriceFeed();
-        assertEq(mockPriceFeed.getPrice(), 0, "getPrice should be 0");
+        assertEq(mockPriceFeed.getPrice(0), 0, "getPrice should be 0");
 
         mockPriceFeed.setPrice(1_000_000_000);
-        assertEq(mockPriceFeed.getPrice(), 1_000_000_000, "getPrice should be 1_000_000_000");
+        assertEq(mockPriceFeed.getPrice(0), 1_000_000_000, "getPrice should be 1_000_000_000");
     }
 }


### PR DESCRIPTION
The price used for determining if the target is low or high should be at the agreed upon market time, not when resolution happens (which could happen arbitrarily far in the future after the market is decided)

I also switched how the tickCumulative is calculated because it was done in reverse before
`ethDegenPool.observe([0, 60]) -> ethDegenPool.observe([60, 0])`
the parameters are in seconds ago, so the bigger number should go first, so that the returned results are in chronological order
that way `(results[1] - results[0]) / 60` will actually result in the average tick during that interval rather than (-avgTick)

Also did some variable renaming since the average is no longer a cumulative statistic
