### PR TITLE
Protect against reentrancy and make more spec compliant

### DIFF
--- a/contracts/src/SteakedDegen.sol
+++ b/contracts/src/SteakedDegen.sol
@@ -95,7 +95,9 @@ contract SteakedDegen is ISteakedDegen, ERC4626, Ownable {
      */
     function previewDeposit(uint256 assets) public view override returns (uint256) {
         uint256 steakFeeAmount = assets * steakFee / FEE_DIVISOR;
+        uint256 daoFeeAmount = assets * daoFee / FEE_DIVISOR;
+        uint256 assetsAfterFee = assets - steakFeeAmount - daoFeeAmount;
         // adapted from _convertToShares, but uses totalAssets + steakFeeAmount instead of totalAssets
-        return assets.mulDiv(totalSupply() + 10 ** _decimalsOffset(), totalAssets() + steakFeeAmount + 1, rounding);
+        return assetsAfterFee.mulDiv(totalSupply() + 10 ** _decimalsOffset(), totalAssets() + steakFeeAmount + 1, rounding);
     }
 }

--- a/contracts/src/SteakedDegen.sol
+++ b/contracts/src/SteakedDegen.sol
@@ -10,6 +10,7 @@ import "openzeppelin/access/Ownable.sol";
 
 contract SteakedDegen is ISteakedDegen, ERC4626, Ownable {
     using SafeERC20 for IERC20;
+    using Math for uint256;
 
     uint256 public steakFee = 69 * 1e2; // 0.69%
     uint256 public daoFee = 69 * 1e2; // 0.69%
@@ -93,7 +94,7 @@ contract SteakedDegen is ISteakedDegen, ERC4626, Ownable {
      * This is an override of previewDeposit to match the shares the user should expect from calling deposit.
      * This is to maintain compliancy with EIP-4626
      */
-    function previewDeposit(uint256 assets) public view override returns (uint256) {
+    function previewDeposit(uint256 assets) public view override(ERC4626, IERC4626) returns (uint256) {
         uint256 steakFeeAmount = assets * steakFee / FEE_DIVISOR;
         uint256 daoFeeAmount = assets * daoFee / FEE_DIVISOR;
         uint256 assetsAfterFee = assets - steakFeeAmount - daoFeeAmount;

--- a/contracts/src/SteakedDegen.sol
+++ b/contracts/src/SteakedDegen.sol
@@ -71,10 +71,10 @@ contract SteakedDegen is ISteakedDegen, ERC4626, Ownable {
         whenInitialized
         returns (uint256)
     {
+        uint256 shares = previewDeposit(assets);
         uint256 steakFeeAmount = assets * steakFee / FEE_DIVISOR;
         uint256 daoFeeAmount = assets * daoFee / FEE_DIVISOR;
         uint256 assetsAfterFee = assets - steakFeeAmount - daoFeeAmount;
-        uint256 shares = previewDeposit(assetsAfterFee);
 
         // slither-disable-next-line reentrancy-no-eth
         SafeERC20.safeTransferFrom(IERC20(asset()), _msgSender(), daoFeeReceiver, daoFeeAmount);

--- a/contracts/src/SteakedDegen.sol
+++ b/contracts/src/SteakedDegen.sol
@@ -98,6 +98,6 @@ contract SteakedDegen is ISteakedDegen, ERC4626, Ownable {
         uint256 daoFeeAmount = assets * daoFee / FEE_DIVISOR;
         uint256 assetsAfterFee = assets - steakFeeAmount - daoFeeAmount;
         // adapted from _convertToShares, but uses totalAssets + steakFeeAmount instead of totalAssets
-        return assetsAfterFee.mulDiv(totalSupply() + 10 ** _decimalsOffset(), totalAssets() + steakFeeAmount + 1, rounding);
+        return assetsAfterFee.mulDiv(totalSupply() + 10 ** _decimalsOffset(), totalAssets() + steakFeeAmount + 1, Math.Rounding.Floor);
     }
 }


### PR DESCRIPTION
This consolidates some of the logic in the overriden `deposit` function to avoid reentrancy attacks and overwrites previewDeposit which according to the spec:
> MUST return as close to and no more than the exact amount of Vault shares that would be minted in a deposit call in the same transaction. I.e. deposit should return the same or more shares as previewDeposit if called in the same transaction.
so that it matches what will occur if deposit is called