### PR TITLE
Fix smart contract bugs

### DIFF
--- a/contracts/script/base/DeploymentPriceFeedOnly.s.sol
+++ b/contracts/script/base/DeploymentPriceFeedOnly.s.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import "forge-std/Script.sol";
+import "script/helpers/WithActionHelpers.s.sol";
+
+contract BaseDeploymentPriceFeedOnly is Script, WithActionHelpers {
+    function run() public {
+        setNetwork(vm.envOr("NETWORK", string("testrun_base")));
+
+        deployPriceFeedOnly();
+    }
+
+    function test_script() public {}
+}

--- a/contracts/script/helpers/WithActionHelpers.s.sol
+++ b/contracts/script/helpers/WithActionHelpers.s.sol
@@ -81,7 +81,7 @@ contract WithActionHelpers is Script, WithFileHelpers {
 
         priceFeed = new PriceFeed({ethDegenPool_: ethDegenPool, ethUsdcPool_: ethUsdcPool});
         degenToken = DegenToken(degenTokenAddress);
-        steakedDegen = new SteakedDegen("Steaked Degen", "SDEGEN", degenToken, address(this));
+        steakedDegen = new SteakedDegen("Steaked Degen", "SDEGEN", degenToken, dude);
         betRegistry = new BetRegistry(degenToken, steakedDegen, IPriceFeed(address(priceFeed)), dude);
         steakedDegen.setFan(address(betRegistry), true);
         betRegistry.setFan(hellno, true);

--- a/contracts/script/helpers/WithActionHelpers.s.sol
+++ b/contracts/script/helpers/WithActionHelpers.s.sol
@@ -288,4 +288,20 @@ contract WithActionHelpers is Script, WithFileHelpers {
     }
 
     function test_WithActionHelpers() public {}
+
+
+    /// @dev
+    function deployPriceFeedOnly() public {
+        uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PK");
+
+        address ethDegenPool = 0xc9034c3E7F58003E6ae0C8438e7c8f4598d5ACAA;
+        address ethUsdcPool = 0x4C36388bE6F416A29C8d8Eee81C771cE6bE14B18;
+        address degenTokenAddress = 0x4ed4E862860beD51a9570b96d89aF5E1B0Efefed;
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        priceFeed = new PriceFeed({ethDegenPool_: ethDegenPool, ethUsdcPool_: ethUsdcPool});
+        
+        vm.stopBroadcast();
+    }
 }

--- a/contracts/shell/deploy_base_pricefeed_only.sh
+++ b/contracts/shell/deploy_base_pricefeed_only.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# To load the variables in the .env file
+source .env
+
+# To deploy and verify our contract
+NETWORK=base forge script script/base/DeploymentPriceFeedOnly.s.sol --rpc-url https://base-mainnet.g.alchemy.com/v2/$ALCHEMY_API_KEY --slow --legacy --broadcast -vvvv 

--- a/contracts/src/BetRegistry.sol
+++ b/contracts/src/BetRegistry.sol
@@ -141,6 +141,8 @@ contract BetRegistry is IBetRegistry, Ownable {
         Market storage market = markets[marketId_];
         require(block.timestamp >= market.endTime, "BetRegistry::resolveMarket: market has not ended.");
         require(block.timestamp >= market.endTime + gracePeriod, "BetRegistry::resolveMarket: grace period not over.");
+        require(market.endPrice == 0, "BetRegistry::resolveMarket: market already resolved.");
+
         uint32 secondsAgo = uint32(block.timestamp - market.endTime);
         uint256 price = priceFeed.getPrice(secondsAgo);
         market.endPrice = price;

--- a/contracts/src/PriceFeed.sol
+++ b/contracts/src/PriceFeed.sol
@@ -37,7 +37,7 @@ contract PriceFeed is IPriceFeed {
         (int56[] memory tickCumulatives,) = ethDegenPool.observe(secondsAgos);
         int56 tickCumulativeDelta = tickCumulatives[1] - tickCumulatives[0];
         int56 avgTick = tickCumulativeDelta / 60; // 0, 60 seconds
-        uint256 quote = OracleLibrary.getQuoteAtTick(int24(avgTick), degenAmount_, WETH_BASE, DEGEN_BASE);
+        uint256 quote = OracleLibrary.getQuoteAtTick(int24(avgTick), degenAmount_, DEGEN_BASE, WETH_BASE);
         return quote;
     }
 
@@ -48,7 +48,7 @@ contract PriceFeed is IPriceFeed {
         (int56[] memory tickCumulatives,) = ethUsdcPool.observe(secondsAgos);
         int56 tickCumulativeDelta = tickCumulatives[1] - tickCumulatives[0];
         int56 avgTick = tickCumulativeDelta / 60; // 0, 60 seconds
-        uint256 quote = OracleLibrary.getQuoteAtTick(int24(avgTick), ethAmount_, USDC_BASE, WETH_BASE);
+        uint256 quote = OracleLibrary.getQuoteAtTick(int24(avgTick), ethAmount_, WETH_BASE, USDC_BASE);
         return quote;
     }
 }


### PR DESCRIPTION
This fixes the bug that allows a market to be resolved more than once

Also attempts fixing an inverted quote error, which converts from 1,000,000 ETH to DEGEN rather than 1,000,000 DEGEN to ETH, etc.
Tests are still broken, but will test on main by deploying just PriceFeed and comparing with real prices.

Then we can figure out why the tests are inversed of how they should be.

It might have to do with how Uniswap identifies token0 and token1 (address hash literal value :sweat_smile: )